### PR TITLE
Implement smooth LFO parameter transitions with continuous processing

### DIFF
--- a/sampler/voice_manager.h
+++ b/sampler/voice_manager.h
@@ -440,10 +440,12 @@ private:
 
     // ===== LFO PANNING STATE =====
 
-    float panSpeed_;                   // LFO frequency in Hz (0.0-2.0)
-    float panDepth_;                   // LFO amplitude (0.0-1.0)
+    float panSpeed_;                   // Current interpolated LFO frequency in Hz (0.0-2.0)
+    float panSpeedTarget_;             // Target LFO frequency from MIDI (0.0-2.0)
+    float panDepth_;                   // Current interpolated LFO depth (0.0-1.0)
+    float panDepthTarget_;             // Target LFO depth from MIDI (0.0-1.0)
+    float panSmoothingTime_;           // Smoothing time for both speed and depth (default: 0.5s)
     float lfoPhase_;                   // Current LFO phase (0.0-2π)
-    float lfoPhaseIncrement_;          // Phase increment per sample
     std::vector<float> lfoPanBuffer_;  // Pre-calculated per-sample pan values
 
     // Členy pro vyhlazování LFO panningu


### PR DESCRIPTION
- Added target-based smoothing for both panSpeed and panDepth (500ms)
- Removed lfoPhaseIncrement_ member, now calculated per-sample from interpolated speed
- Simplified logic: LFO runs continuously regardless of speed/depth values
- Removed conditional checks in processBlock functions
- Fixed depth 0→1 transition clicks by always updating previousPan state
- Fixed speed transitions by interpolating speed directly (not phase increment)
- Symmetrical implementation for both speed and depth parameters

This eliminates all audible clicks/pops when changing LFO parameters via MIDI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)